### PR TITLE
Add wavedrom 3.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "prism-themes": "1.9.0",
     "prismjs": "1.29.0",
     "quicklink": "2.3.0",
-    "ribbon.js": "1.0.2"
+    "ribbon.js": "1.0.2",
+    "wavedrom": "3.2.0"
   },
   "devDependencies": {
     "css": "3.0.0",


### PR DESCRIPTION
This change is the prerequisite change for adding wavedrom support in next theme.

Currently, the main version of wavedrom 3.2.0, which is also published in cdnjs too: https://cdnjs.com/libraries/wavedrom.